### PR TITLE
Proper cleanups

### DIFF
--- a/io.github.ezQuake.yaml
+++ b/io.github.ezQuake.yaml
@@ -18,6 +18,8 @@ cleanup:
 - /include
 - /lib/*.a
 - /lib/*.la
+- /lib/cmake
+- /lib/debug
 - /lib/pkgconfig
 
 modules:

--- a/io.github.ezQuake.yaml
+++ b/io.github.ezQuake.yaml
@@ -15,10 +15,10 @@ finish-args:
 - --persist=.ezquake
 
 cleanup:
-- /app/include
-- /app/lib/*.a
-- /app/lib/*.la
-- /app/lib/pkgconfig
+- /include
+- /lib/*.a
+- /lib/*.la
+- /lib/pkgconfig
 
 modules:
 


### PR DESCRIPTION
- **Manifest: Properly clean up**
  The paths under `cleanup` are prepended with `/app/` by flatpak-builder
  so it would actually clean out `/app/app/include` etc.
  Fix this by removing the /app prefix.


- **Manifest: Also cleanup cmake and debug stuff**
  This isn't needed runtime so clean this up.
