### PR TITLE
Update to 3.6.0

### DIFF
--- a/io.github.ezQuake.yaml
+++ b/io.github.ezQuake.yaml
@@ -18,7 +18,6 @@ cleanup:
   - /lib/*.a
   - /lib/*.la
   - /lib/cmake
-  - /lib/debug
   - /lib/pkgconfig
 
 modules:

--- a/io.github.ezQuake.yaml
+++ b/io.github.ezQuake.yaml
@@ -43,8 +43,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/ezQuake/ezquake-source
-        tag: 3.2.3
-        commit: e7ecc1f1969504751d4252d58a27c9e015796ec9
+        tag: 3.6.0
+        commit: f85f6ee7036cbb97af69a2d936fbda52046a684d
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+)$


### PR DESCRIPTION
Not actually a stable version! There was some confusion on my end but 3.6.0 is just 3.6-dev-alpha10-dev with a new name.

Current stable versions:

http://www.ezquake.com/downloads.html